### PR TITLE
improve loading of FFI for rubinius support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y librdf0 
+script: bundle exec rake spec
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.1.1
+  - 2.1.2
+  - ruby-head
+  - rbx-1.3.3
+  - rbx-2
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-head
+cache: bundler

--- a/spec/integration/ruby_engine_spec.rb
+++ b/spec/integration/ruby_engine_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe Redland do
+  subject(:redland) {
+    Redland
+  }
+
+  it "can load FFI library" do
+    expect {
+      redland::load_ffi
+    }.not_to raise_error
+  end
+
+  it "can load librdf shared library" do
+    expect {
+      redland::load_ffi
+      redland.librdf_new_world
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
tested loading FFI / librdf under rubinius, jruby, and mri

added integration spec to ensure loading FFI and librdf does not raise
errors

added travis-ci configuration to run test suite on mri, jruby, and
rubinius
