### PR TITLE
copy librdf_node pointer on statement construction

### DIFF
--- a/lib/redlander/statement.rb
+++ b/lib/redlander/statement.rb
@@ -121,9 +121,9 @@ module Redlander
       when NilClass
         nil
       when Node
-        source.rdf_node
+        Redland.librdf_new_node_from_node(source.rdf_node)
       else
-        Node.new(source).rdf_node
+        Redland.librdf_new_node_from_node(Node.new(source).rdf_node)
       end
     end
   end

--- a/spec/integration/finalizer_gc_spec.rb
+++ b/spec/integration/finalizer_gc_spec.rb
@@ -67,10 +67,8 @@ describe "garbage collection" do
     GC.start
     expect(ObjectSpace.each_object(Model).count).to eq(0)
     expect(ObjectSpace.each_object(Statement).count).to eq(0)
-    expect(ObjectSpace.each_object(Node).count).to eq(0)
     expect(ObjectSpace.each_object(Query::Results).count).to eq(0)
   end
-
 
   private
 


### PR DESCRIPTION
librdf_new_node_from_node will increase the reference count
for the librdf_node to match the corresponding free of both
librdf_node(s) and librdf_statement term(s).  Incrementing
and decrementing the reference count allows the raptor_term
to be free'd only when nothing else references it.

refs #3
