### PR TITLE
"Lazy loading" of Statement, Node and Uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ which is used to manipulate RDF graphs. This is an alternative implementation
 of Ruby bindings (as opposed to the official bindings), aiming to be more
 intuitive, lightweight, high-performing and as bug-free as possible.
 
+
 # Installing
 
 Installing Redlander is simple:
@@ -12,6 +13,7 @@ Installing Redlander is simple:
     $ gem install redlander
 
 Note, that you will have to install Redland runtime library (librdf) for Redlander to work.
+
 
 # Usage
 
@@ -28,6 +30,7 @@ like `:user` or `:password`. Look-up the options for `Model.initialize`
 for the list of available options.
 Naturally, you don't need to create a model if you just want to play around
 with independent statements, nodes and the like.
+
 
 ## RDF Statements
 
@@ -52,7 +55,8 @@ The API is almost identical to [ActiveRecord](https://github.com/rails/rails/tre
 
     $ m.statements.each { |st| puts st }
 
-Finding statements:
+
+### Finding and enumerating statements
 
     $ m.statements.find(:first, :object => "subject!")
     $ m.statements.all(:object => "another label")
@@ -60,7 +64,20 @@ Finding statements:
         puts statement.subject
       }
 
-Note that `m.statements.each` is "lazy", while `m.statements.all` (and other finders) is not.
+Note that `m.statements.each` does not have to pull and instantiate all statements in one call,
+while `m.statements.all` (and other finders) can potentially create huge arrays of data
+before you can handle individual statements of it.
+
+For those interested in laziness, `m.statements` has `lazy` method which works exactly as users of
+Ruby 2+ would expect:
+
+    $ m.statements.lazy.each {|s| puts s.object }
+
+This, and other similar features are inherited by `m.statements` (which is actually an instance of
+`Redlander::ModelProxy`) from `Enumerable` module.
+
+
+### Accessing and querying subject, predicate and object
 
 You can access the subject, predicate or object of a statement:
 
@@ -81,6 +98,7 @@ yields the statements constructed by *CONSTRUCT* queries and yields the binding
 hash for *SELECT* queries. Binding hash values are instances of `Redlander::Node`.
 
 For query options and available query languages refer to `Model#query` documentation.
+
 
 ### Localized string literals
 

--- a/lib/redlander/uri.rb
+++ b/lib/redlander/uri.rb
@@ -3,7 +3,21 @@ module Redlander
   # Uri (for internal use)
   class Uri
     # @api private
-    attr_reader :rdf_uri
+    def rdf_uri
+      unless instance_variable_defined?(:@rdf_uri)
+        @rdf_uri = case @source
+                   when FFI::Pointer
+                     @source
+                   when URI, String
+                     Redland.librdf_new_uri(Redlander.rdf_world, @source.to_s)
+                   else
+                     raise NotImplementedError, "Cannot create Uri from '#{@source.inspect}'"
+                   end
+        raise RedlandError, "Failed to create Uri from '#{@source.inspect}'" if @rdf_uri.null?
+        ObjectSpace.define_finalizer(self, self.class.send(:finalize_uri, @rdf_uri))
+      end
+      @rdf_uri
+    end
 
     class << self
       private
@@ -20,24 +34,15 @@ module Redlander
     # @raise [NotImplementedError] if cannot create a Uri from the given source.
     # @raise [RedlandError] if it fails to create a Uri.
     def initialize(source)
-      @rdf_uri = case source
-                 when FFI::Pointer
-                   wrap(source)
-                 when URI, String
-                   Redland.librdf_new_uri(Redlander.rdf_world, source.to_s)
-                 else
-                   raise NotImplementedError, "Cannot create Uri from '#{source.inspect}'"
-                 end
-      raise RedlandError, "Failed to create Uri from '#{source.inspect}'" if @rdf_uri.null?
-      ObjectSpace.define_finalizer(self, self.class.send(:finalize_uri, @rdf_uri))
+      @source = source.is_a?(FFI::Pointer) ? wrap(source) : source
     end
 
     def to_s
-      Redland.librdf_uri_to_string(@rdf_uri)
+      Redland.librdf_uri_to_string(rdf_uri)
     end
 
     def eql?(other_uri)
-      other_uri.is_a?(Uri) && (Redland.librdf_uri_equals(@rdf_uri, other_uri.rdf_uri) != 0)
+      other_uri.is_a?(Uri) && (Redland.librdf_uri_equals(rdf_uri, other_uri.rdf_uri) != 0)
     end
     alias_method :==, :eql?
 


### PR DESCRIPTION
Ruby objects for Statement, Node and Uri classes are instantiated "lazily" and there are no calls made to FFI (and, subsequently, to the underlying storage) unless it is absolutely necessary.
Previously, just a single `Statement.new(...)` statement introduced at least 1 to 4 calls, now it works as follows:

```
s = Statement.new(...)  # creates a plain Ruby object without calls to FFI
s.subject  # this where the necessary calls are made
```

Also notice that `subject`, `predicate`, `object` and several other accessors memoize their values to avoid the call to FFI (and the storage). For example, once `Statement.subject` is set, there won't be calls made to FFI to read it:

```
s = Statement.new(...)
s.subject = node  # node is put into the storage
puts s.subject  # storage is never accessed to get this value from now on
```

@abargnesi Do you think this makes sense? If it does, could you benchmark your project with it and see if it yields any boost? Thank you!
