### PR TITLE
Provide JRuby support for model iterating

### DIFF
--- a/lib/redlander.rb
+++ b/lib/redlander.rb
@@ -13,15 +13,17 @@ require 'redlander/statement'
 module Redlander
   class << self
 
+    RDF_WORLD = Redland.librdf_new_world
+    Redland.librdf_world_open(RDF_WORLD)
+    if Redland::jruby?
+      raptor_world_ptr = Redland.raptor_new_world_internal(Redland.raptor_version_decimal)
+      Redland.raptor_world_set_flag(raptor_world_ptr, :RAPTOR_WORLD_FLAG_URI_INTERNING, 0)
+      Redland.librdf_world_set_raptor(RDF_WORLD, raptor_world_ptr)
+    end
+
     # @api private
     def rdf_world
-      unless @rdf_world
-        @rdf_world = Redland.librdf_new_world
-        raise RedlandError, "Could not create a new RDF world" if @rdf_world.null?
-        ObjectSpace.define_finalizer(self, finalize_world(@rdf_world))
-        Redland.librdf_world_open(@rdf_world)
-      end
-      @rdf_world
+      RDF_WORLD
     end
 
 

--- a/lib/redlander/node.rb
+++ b/lib/redlander/node.rb
@@ -14,7 +14,7 @@ module Redlander
     def rdf_node
       unless instance_variable_defined?(:@rdf_node)
         @rdf_node = case @arg
-                    when FFI::Pointer
+                    when Redland::FFI::Pointer
                       @arg
                     when NilClass
                       Redland.librdf_new_node_from_blank_identifier(Redlander.rdf_world, @options[:blank_id])
@@ -62,9 +62,9 @@ module Redlander
     # @option options [Boolean] :resource interpret arg as URI string and create an RDF "resource".
     # @raise [RedlandError] if it fails to create a node from the given args.
     def initialize(arg = nil, options = {})
-      # If FFI::Pointer is passed, wrap it instantly,
+      # If Redland::FFI::Pointer is passed, wrap it instantly,
       # because it can be freed outside before it is used here.
-      @arg = arg.is_a?(FFI::Pointer) ? wrap(arg) : arg
+      @arg = arg.is_a?(Redland::FFI::Pointer) ? wrap(arg) : arg
       @options = options
     end
 

--- a/lib/redlander/statement.rb
+++ b/lib/redlander/statement.rb
@@ -14,7 +14,7 @@ module Redlander
     def rdf_statement
       unless instance_variable_defined?(:@rdf_statement)
         @rdf_statement = case @source
-                         when FFI::Pointer
+                         when Redland::FFI::Pointer
                            @source
                          when Hash
                            # Create a new statement from nodes
@@ -40,9 +40,9 @@ module Redlander
     # @raise [NotImplementedError] if cannot create a Statement from the given source.
     # @raise [RedlandError] if it fails to create a Statement.
     def initialize(source = {})
-      # If FFI::Pointer is passed, wrap it instantly,
+      # If Redland::FFI::Pointer is passed, wrap it instantly,
       # because it can be freed outside before it is used here.
-      @source = source.is_a?(FFI::Pointer) ? wrap(source) : source
+      @source = source.is_a?(Redland::FFI::Pointer) ? wrap(source) : source
     end
 
     # Subject of the statment.

--- a/lib/redlander/uri.rb
+++ b/lib/redlander/uri.rb
@@ -6,7 +6,7 @@ module Redlander
     def rdf_uri
       unless instance_variable_defined?(:@rdf_uri)
         @rdf_uri = case @source
-                   when FFI::Pointer
+                   when Redland::FFI::Pointer
                      @source
                    when URI, String
                      Redland.librdf_new_uri(Redlander.rdf_world, @source.to_s)
@@ -34,7 +34,7 @@ module Redlander
     # @raise [NotImplementedError] if cannot create a Uri from the given source.
     # @raise [RedlandError] if it fails to create a Uri.
     def initialize(source)
-      @source = source.is_a?(FFI::Pointer) ? wrap(source) : source
+      @source = source.is_a?(Redland::FFI::Pointer) ? wrap(source) : source
     end
 
     def to_s


### PR DESCRIPTION
Includes the following enhancement:
- Loads the correct FFI implementation for your ruby engine.
- Initialize the librdf_world pointer at require time to avoid
  thread-safey issues during lazy initialization.
- When JRuby, disable raptor's URI interning feature because it is not
  thread-safe. This was accomplished by calling raptor functions to
  configure a raptor_world without the uri interning feature.

Issues with these enhancements:
- Requires the caller to create a Redlander::Model per thread to avoid
  additional threading issues encountered in librdf (related to
  librdf_free_stream and librdf_node_normalize).
- JRuby tests segfault related to librdf_parser pointers.
